### PR TITLE
Add dockerized build

### DIFF
--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+
+cd docker
+docker build -t sirius-builder .
+cd -
+
+DOCKER="docker run -it --rm -v $(pwd):$(pwd) -w $(pwd) -u $(id -u):$(id -g) sirius-builder"
+
+$DOCKER ./prepare-env.sh || true # Ignore errors if packages already exists
+$DOCKER make

--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,8 @@
-export CROSS_COMPILE := /home/zt/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-
-export CROSS_COMPILE_AARCH64 := /home/zt/optee/toolchains/aarch64/bin/aarch64-linux-gnu-
+ifndef CROSS_COMPILE
+CROSS_COMPILE=/home/zt/optee/toolchains/aarch32/bin/arm-linux-gnueabihf-
+endif
+
+ifndef CROSS_COMPILE_AARCH64
+CROSS_COMPILE_AARCH64=/home/zt/optee/toolchains/aarch64/bin/aarch64-linux-gnu-
+endif
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,23 +3,23 @@ FROM ubuntu:20.04
 RUN sed -i '/deb-src/s/^# //' /etc/apt/sources.list && \
 	dpkg --add-architecture i386 && \
 	apt-get update && \
-	apt-get install -y build-essential git gcc-arm-linux-gnueabihf sudo bison flex libssl-dev bc kmod wget vim u-boot-tools
+	apt-get install -y build-essential git sudo bison flex libssl-dev bc kmod wget vim u-boot-tools
 
 # Download optee toolchains
 RUN mkdir -p /toolchains && \
 	cd /toolchains && \
-	wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.2-2019.01/gcc-arm-8.2-2019.01-x86_64-arm-linux-gnueabihf.tar.xz && \
-	wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.2-2019.01/gcc-arm-8.2-2019.01-x86_64-aarch64-linux-gnu.tar.xz
+	wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz && \
+	wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz
 
 RUN cd /toolchains && \
 	mkdir aarch32 && \
 	umask 022 && \
-	tar xf gcc-arm-8.2-2019.01-x86_64-arm-linux-gnueabihf.tar.xz -C aarch32 --strip-components=1
+	tar xf *-arm-linux-gnueabihf.tar.xz -C aarch32 --strip-components=1
 
 RUN cd /toolchains && \
 	mkdir aarch64 && \
 	umask 022 && \
-	tar xf gcc-arm-8.2-2019.01-x86_64-aarch64-linux-gnu.tar.xz -C aarch64 --strip-components=1
+	tar xf *-aarch64-linux-gnu.tar.xz -C aarch64 --strip-components=1
 
 ENV CROSS_COMPILE /toolchains/aarch32/bin/arm-linux-gnueabihf-
 ENV CROSS_COMPILE_AARCH64 /toolchains/aarch64/bin/aarch64-linux-gnu-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04
+
+RUN sed -i '/deb-src/s/^# //' /etc/apt/sources.list && \
+	dpkg --add-architecture i386 && \
+	apt-get update && \
+	apt-get install -y build-essential git gcc-arm-linux-gnueabihf sudo bison flex libssl-dev bc kmod wget vim u-boot-tools
+
+# Download optee toolchains
+RUN mkdir -p /toolchains && \
+	cd /toolchains && \
+	wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.2-2019.01/gcc-arm-8.2-2019.01-x86_64-arm-linux-gnueabihf.tar.xz && \
+	wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.2-2019.01/gcc-arm-8.2-2019.01-x86_64-aarch64-linux-gnu.tar.xz
+
+RUN cd /toolchains && \
+	mkdir aarch32 && \
+	umask 022 && \
+	tar xf gcc-arm-8.2-2019.01-x86_64-arm-linux-gnueabihf.tar.xz -C aarch32 --strip-components=1
+
+RUN cd /toolchains && \
+	mkdir aarch64 && \
+	umask 022 && \
+	tar xf gcc-arm-8.2-2019.01-x86_64-aarch64-linux-gnu.tar.xz -C aarch64 --strip-components=1
+
+ENV CROSS_COMPILE /toolchains/aarch32/bin/arm-linux-gnueabihf-
+ENV CROSS_COMPILE_AARCH64 /toolchains/aarch64/bin/aarch64-linux-gnu-
+
+# Additional optee build deps
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
+RUN apt-get install -y android-tools-adb android-tools-fastboot \
+	autoconf automake bc bison build-essential ccache cscope curl device-tree-compiler \
+        expect flex ftp-upload gdisk iasl libattr1-dev libc6:i386 libcap-dev \
+        libfdt-dev libftdi-dev libglib2.0-dev libhidapi-dev libncurses5-dev \
+        libpixman-1-dev libssl-dev libstdc++6:i386 libtool libz1:i386 make \
+        mtools netcat python-crypto python3-crypto python-pyelftools \
+        python3-pycryptodome python3-pyelftools \
+        rsync unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev python

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+## Docker build environment
+
+The Dockerfile contains Ubuntu dependencies required by OPTEE etc and ARM
+toolchains for aarch32 and aarch64.
+
+To build and tag as `sirius-builder`:
+
+$ docker build -t sirius-builder .
+
+To use it as an interative build environment:
+
+```
+$ cd ..
+$ docker run -it -rm -v $(pwd):$(pwd) -w $(pwd) sirius-builder:latest
+```
+
+
+.. or to run e.g. make (note that build artefacts will be owned by root unless
+-u is specified):
+
+```
+$ cd ..
+$ docker run -it -rm -v $(pwd):$(pwd) -w $(pwd) sirius-builder:latest make
+```

--- a/prepare-env.sh
+++ b/prepare-env.sh
@@ -78,16 +78,15 @@
 	}
 }
 
-[ -f "./dl/linux.tar.gz" ] && {
-	echo  "\033[32mlinux package existed.\n\033[0m"
-} || {
-	echo  "\033[32mlinux downloading...\n\033[0m"
-	wget -O dl/linux.tar.gz https://github.com/raspberrypi/linux/archive/raspberrypi-kernel_1.20190215-1.tar.gz
-}
 
 [ ! -d "./linux" ] && {
+	[ -f "./dl/linux.tar.gz" ] && {
+		echo  "\033[32mlinux package existed.\n\033[0m"
+	} || {
+		echo  "\033[32mlinux downloading...\n\033[0m"
+		wget -O dl/linux.tar.gz https://github.com/raspberrypi/linux/archive/raspberrypi-kernel_1.20190215-1.tar.gz
+	}
 	tar zxf dl/linux.tar.gz && {
 		mv linux-* linux
 	}
 }
-


### PR DESCRIPTION
Adds a Dockerfile w/dependencies and ARM toolchains + a new build script that uses it (`build-in-docker.sh`).

The build script will mount `$(pwd)` in the container and then run `prepare-env.sh` and `make` inside it. It uses the uid/gid of the local user internally to avoid that the files produced are owned by root on linux.

When the build is complete the binaries are in `./out/rootfs` and `./out/boot` as usual.