### PR TITLE
Add arm_64bit option to config

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -61,3 +61,5 @@ kernel_address=0x02000000
 
 device_tree_address=0x01000000
 
+# enable 64 bit mode on newer (~ >2019-07-10) raspbian images
+arm_64bit=1

--- a/firmware/config.txt
+++ b/firmware/config.txt
@@ -61,3 +61,5 @@ kernel_address=0x02000000
 
 device_tree_address=0x01000000
 
+# enable 64 bit mode on newer (~ >2019-07-10) raspbian images
+arm_64bit=1


### PR DESCRIPTION
Newer raspbian firmware (ca 2019-07-10 and onwards) include support for 64-bit beta kernels which can be enabled with the `arm_64bit` option in `config.txt` - it is disabled by default. This seems to also affect whether it loads the 64-bit `armstub8.bin` required by this project. On some raspbian releases it crashes during boot without this option and on the latest ones `armstub8.bin` is just ignored and the system boots using the regular kernel.

Enabling `arm_64bit` loads `armstub8.bin` and it also successfully goes back to 32-bit mode when the custom kernel is booted (as was also the previous behaviour).

I have tested this manually on `2020-02-13-raspbian-buster` by running `tee-supplicant` and then verified that `optee_example_random` returns a number. I've tested it on both rpi3b and rpi3b+.